### PR TITLE
t0, eta0 interpolation and adaptive time steps

### DIFF
--- a/ChannelMaps_main.py
+++ b/ChannelMaps_main.py
@@ -5,6 +5,10 @@ import os
 import ChannelMaps_functions as f
 import ChannelMaps_settings as s
 
+from GridMapper import grid_mapper
+
+import matplotlib.pyplot as plt
+
 
 if len(sys.argv) != 2:
     print("Error!")
@@ -22,6 +26,9 @@ os.makedirs(path, exist_ok=True)
 print('~ Creating Keplerian velocity field ...')
 vK = f.create_Keplerian_velocity_field()
 
+#plt.plot(s.r, vK[0,:])
+#plt.show()
+
 print('~ Uploading linear perturbations ...')
 xl,yl,dl,ul,vl = f.upload_linear_perturbations()
 
@@ -29,7 +36,24 @@ print('~ Adding linear perturbations to Keplerian velocity field ...')
 vr,vphi,deltav = f.vKepler_plus_linear_pert(xl,yl,ul,vl,vK)
 
 print('~ Nonlinear perturbations:')
+#dnl,unl,vnl = f.compute_nonlinear_pert_cartesian()
 dnl,unl,vnl = f.compute_nonlinear_pert()
+
+"""
+unl = 20*unl
+vnl = 20*vnl
+"""
+
+"""
+plt.imshow(dnl)
+plt.show()
+plt.imshow(unl)
+plt.show()
+plt.imshow(vnl)
+plt.show()
+"""
+
+
 
 print('~ Adding nonlinear perturbations ...')
 vr,vphi,deltav = f.add_nonlinear_pert(unl,vnl,vr,vphi,deltav,vK)
@@ -49,7 +73,11 @@ np.save(path + 'vphi.npy', vphi)
 np.save(path + 'deltavphi.npy', vphi - (-s.cw * vK))
 np.save(path + 'deltav.npy', deltav)
 
+#print('~ Interpolating to new grid')
 
+#grid_mapper(path)
+
+"""
 print('~ Making figures ...')
 f.make_contourplot(deltav, bar_label='$\\delta v(r,\\varphi)$', saveas = path +'delta_v')
 f.make_contourplot(vphi - (-s.cw * vK), bar_label='$v(r,\\varphi)$  [km/s]', saveas = path + 'azimuthal_vel_pert')
@@ -70,5 +98,6 @@ if np.ndim(s.vchs) > 0:
 
     print('~ Making channel maps plot ...')
     f.make_contourplot(v_field[:,:,2]-v_field0[:,:,2], bar_label='$\\Delta v_n (r,\\varphi)$   [km/s]', WithChannels = True, vz_field = v_field[:,:,2], saveas = path + 'contour.pdf')
+"""
 
 print('~ Done! \n')

--- a/ChannelMaps_settings.py
+++ b/ChannelMaps_settings.py
@@ -44,7 +44,7 @@ def init(file):
     global M, Mp, Rdisc, Rp, cw, q, p, hr, malpha, indad
     global PA, PAp, i, xi
     global vchs, delta_vch
-    global Nr, Nphi, Rmin, x_match
+    global Nr, Nphi, Rmin, x_match, CFL
     global show,xrange,yrange,density,name
 
     params = read_parameters(file)
@@ -110,6 +110,7 @@ def init(file):
 
     Nr = int(params['Nr'])
     Nphi = int(params['Nphi'])
+    CFL = float(params['CFL'])
     x_match = float(params['x_MatchLinearAndNonlinear'])
 
     if 'Rmin' in params.keys():
@@ -118,11 +119,11 @@ def init(file):
         Rmin = Rdisc/50
 
 
-    global R,PHI,X,Y
+    global R,PHI,X,Y,r
     global disc_edge
 
-    r = np.linspace(Rmin,Rdisc,Nr)
-    #r = np.geomspace(Rmin,Rdisc,Nr)
+    #r = np.linspace(Rmin,Rdisc,Nr)
+    r = np.geomspace(Rmin,Rdisc,Nr)
     phi = np.linspace(0,2*np.pi,Nphi)
     R,PHI = np.meshgrid(r,phi)
     X = R*np.cos(PHI)

--- a/Plots.py
+++ b/Plots.py
@@ -41,4 +41,4 @@ if np.ndim(s.vchs) > 0:
     v_field = f.rotate_velocity_field(v_field)
 
     print('~ Making channel maps plot ...')
-    f.make_contourplot(v_field[:,:,2]-v_field0[:,:,2], bar_label='$\\Delta v_n (r,\\varphi)$   [km/s]', WithChannels = True, vz_field = v_field[:,:,2], saveas = 'contour.pdf')
+    f.make_contourplot(v_field[:,:,2]-v_field0[:,:,2], bar_label='$\\Delta v_n (r,\\varphi)$   [km/s]', WithChannels = True, vz_field = v_field[:,:,2], saveas = dir + 'contour.pdf')

--- a/help.param
+++ b/help.param
@@ -26,6 +26,7 @@ Nr 200                        % number of radial grid points
 Nphi 200                      % number or azimuthal grid points
 x_MatchLinearAndNonlinear  2  % half of the liner box side in units of 2*h_p/3 (section 2.3 Bollati et al. 2021)
 Rmin 10                       % (optional) minimun disc radius in AU. Default Rmin = Rdisc/50
+CFL                           % CFL for finite-volume scheme for burgers eqn
 
 
 


### PR DESCRIPTION
The t0 and eta0 values generated from the grid points (r, phi), now have their perturbation solution linearly interpolated from the nearest 4 points on the (t, eta) grid for which there are solutions, instead of simply choosing the closest point with a solution.

Additionally, the code now chooses the time step for the burger's eqn solver adaptively, based off a CFL factor that is chosen as an input parameter.